### PR TITLE
switch and cleanup servers and change title

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,7 +3,7 @@
     <div class="logo-container">
       <img src="assets/ahdis-logo.svg" />
     </div>
-    <span>FHIR Questionnaire Example</span>
+    <span>matchbox form-filler</span>
   </div>
   <!-- This fills the remaining space of the current row -->
   <span class="example-fill-remaining-space"> </span>

--- a/src/app/fhirConfig.service.ts
+++ b/src/app/fhirConfig.service.ts
@@ -7,7 +7,7 @@ import FhirClient from 'fhir-kit-client';
 })
 export class FhirConfigService {
   private fhirMicroServer = new BehaviorSubject(
-    'https://test.ahdis.ch/matchbox-order/fhir'
+    'https://test.ahdis.ch/matchbox/fhir'
   );
   fhirMicroService = this.fhirMicroServer.asObservable();
 

--- a/src/app/igs/igs.component.ts
+++ b/src/app/igs/igs.component.ts
@@ -99,6 +99,7 @@ export class IgsComponent implements OnInit {
         {
           resource: {
             resourceType: 'ImplementationGuide',
+            name: this.addPackageId.value,
             version: this.addVersion.value,
             packageId: this.addPackageId.value,
           },

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -19,17 +19,13 @@ import * as outgoingBundleJson from '../../examples/bundle-outgoing.json';
 })
 export class SettingsComponent implements OnInit {
   fhirServers = [
-    'https://test.ahdis.ch/matchbox-order/fhir',
-    'https://test.ahdis.ch/r4',
-    'http://test.ahdis.ch/r4',
-    'http://localhost:8080/r4',
-    'http://localhost:8080/r4',
-    'http://localhost:8081/r4',
-    'http://test.fhir.org/r4',
-    'http://localhost:8080/matchbox-validator/fhir',
-    'https://test.ahdis.ch/matchbox-validator/fhir',
+    'https://test.ahdis.ch/matchbox/fhir',
+    'http://localhost:8080/matchbox/fhir',
+    'https://ehealthsuisse.ihe-europe.net/matchbox-validator/fhir/',
     'https://hapi.fhir.org/baseR4',
     'http://hapi.fhir.org/baseR4',
+    'http://tx.fhir.org/r4/',
+    'http://test.fhir.org/r4',
   ];
 
   subscription: Subscription;

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>FHIR Questionnaire Example</title>
+    <title>matchbox form-filler</title>
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />


### PR DESCRIPTION
new server is deployed for hl7 connectathon / swiss projectaton on git push --set-upstream origin server_matchbox

this adds the new server, cleaned up old server and changed the title of the app.

if you verify everything is working for the demo will take down matchbox-order