### PR TITLE
remove empty element text (issue #111)

### DIFF
--- a/src/examples/radorder.json
+++ b/src/examples/radorder.json
@@ -8,10 +8,6 @@
       "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-extract"
     ]
   },
-  "text": {
-    "status": "generated",
-    "div": ""
-  },
   "extension": [
     {
       "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-targetStructureMap",


### PR DESCRIPTION
@joelfisch 
Das von Michael angesprochene Validierungsproblem des Questionnaires kommt von diesem leeren Element "text". Wie mit Oliver besprochen, würden wir das weglassen. Ist das aus deiner Sicht auch in Ordnung?

Das muss ich noch auf den Server laden oder? Geht das so?
- https://ahdis.github.io/matchbox-formfiller/#/settings
- https://test.ahdis.ch/matchbox-order/fhir
- Create/update radorder questionnaire